### PR TITLE
Creation date and allocation date for work items

### DIFF
--- a/src/Workflow/Activity/Task.php
+++ b/src/Workflow/Activity/Task.php
@@ -160,6 +160,30 @@ class Task implements ActivityInterface, \Serializable
     /**
      * {@inheritDoc}
      */
+    public function getCreationDate()
+    {
+        if (count($this->workItems) == 0) {
+            return null;
+        }
+
+        return $this->workItems[count($this->workItems) - 1]->getCreationDate();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllocationDate()
+    {
+        if (count($this->workItems) == 0) {
+            return null;
+        }
+
+        return $this->workItems[count($this->workItems) - 1]->getAllocationDate();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getStartDate()
     {
         if (count($this->workItems) == 0) {

--- a/src/Workflow/Activity/WorkItem.php
+++ b/src/Workflow/Activity/WorkItem.php
@@ -19,6 +19,16 @@ class WorkItem implements WorkItemInterface, \Serializable
     /**
      * @var \DateTime
      */
+    private $creationDate;
+
+    /**
+     * @var \DateTime
+     */
+    private $allocationDate;
+
+    /**
+     * @var \DateTime
+     */
     private $startDate;
 
     /**
@@ -38,6 +48,7 @@ class WorkItem implements WorkItemInterface, \Serializable
 
     public function __construct()
     {
+        $this->creationDate = new \DateTime();
     }
 
     /**
@@ -86,6 +97,22 @@ class WorkItem implements WorkItemInterface, \Serializable
     /**
      * {@inheritDoc}
      */
+    public function getCreationDate()
+    {
+        return $this->creationDate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllocationDate()
+    {
+        return $this->allocationDate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getStartDate()
     {
         return $this->startDate;
@@ -121,6 +148,7 @@ class WorkItem implements WorkItemInterface, \Serializable
     public function allocate(ParticipantInterface $participant)
     {
         $this->currentState = self::STATE_ALLOCATED;
+        $this->allocationDate = new \DateTime();
         $this->participant = $participant;
     }
 

--- a/src/Workflow/Activity/WorkItemInterface.php
+++ b/src/Workflow/Activity/WorkItemInterface.php
@@ -36,6 +36,16 @@ interface WorkItemInterface extends EntityInterface
     /**
      * @return \DateTime
      */
+    public function getCreationDate();
+
+    /**
+     * @return \DateTime
+     */
+    public function getAllocationDate();
+
+    /**
+     * @return \DateTime
+     */
     public function getStartDate();
 
     /**

--- a/tests/Workflow/WorkflowTest.php
+++ b/tests/Workflow/WorkflowTest.php
@@ -108,6 +108,8 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
         $this->assertThat($currentFlowObject, $this->isInstanceOf('PHPMentors\Workflower\Workflow\Activity\ActivityInterface'));
         $this->assertThat($currentFlowObject->getId(), $this->equalTo('RecordLoanApplicationInformation'));
         $this->assertThat($currentFlowObject->getCurrentState(), $this->equalTo(WorkItemInterface::STATE_STARTED));
+        $this->assertThat($currentFlowObject->getCreationDate(), $this->isInstanceOf('DateTime'));
+        $this->assertThat($currentFlowObject->getAllocationDate(), $this->isInstanceOf('DateTime'));
         $this->assertThat($currentFlowObject->getStartDate(), $this->isInstanceOf('DateTime'));
     }
 
@@ -315,6 +317,8 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
             $this->assertThat($activityLogEntry->getActivity()->getId(), $this->equalTo($activityIds[$i]));
             $this->assertThat($activityLogEntry->getWorkItem()->getCurrentState(), $this->equalTo(WorkItemInterface::STATE_ENDED));
             $this->assertThat($activityLogEntry->getWorkItem()->getParticipant(), $this->identicalTo($participant));
+            $this->assertThat($activityLogEntry->getWorkItem()->getCreationDate(), $this->isInstanceOf('DateTime'));
+            $this->assertThat($activityLogEntry->getWorkItem()->getAllocationDate(), $this->isInstanceOf('DateTime'));
             $this->assertThat($activityLogEntry->getWorkItem()->getStartDate(), $this->isInstanceOf('DateTime'));
             $this->assertThat($activityLogEntry->getWorkItem()->getEndDate(), $this->isInstanceOf('DateTime'));
             $this->assertThat($activityLogEntry->getWorkItem()->getEndParticipant(), $this->identicalTo($participant));


### PR DESCRIPTION
`WorkItemInterface::getCreationDate()` and `WorkItemInterface::getAllocationDate()` to get the creation/allocation date of a work item.