### PR TITLE
enabled to inject ExpressionLanguage to Workflow

### DIFF
--- a/src/Workflow/Workflow.php
+++ b/src/Workflow/Workflow.php
@@ -86,6 +86,11 @@ class Workflow implements EntityInterface, IdentifiableInterface, \Serializable
     private $stateMachine;
 
     /**
+     * @var ExpressionLanguage
+     */
+    private $expressionLanguage;
+
+    /**
      * @param int|string $id
      * @param string     $name
      */
@@ -367,6 +372,14 @@ class Workflow implements EntityInterface, IdentifiableInterface, \Serializable
     }
 
     /**
+     * @param ExpressionLanguage $expressionLanguage
+     */
+    public function setExpressionLanguage(ExpressionLanguage $expressionLanguage)
+    {
+        $this->expressionLanguage = $expressionLanguage;
+    }
+
+    /**
      * @param EndEvent $event
      */
     private function end(EndEvent $event)
@@ -444,7 +457,7 @@ class Workflow implements EntityInterface, IdentifiableInterface, \Serializable
                         $selectedSequenceFlow = $connectingObject;
                         break;
                     } else {
-                        $expressionLanguage = new ExpressionLanguage();
+                        $expressionLanguage = $this->expressionLanguage ?: new ExpressionLanguage();
                         if ($expressionLanguage->evaluate($condition, $this->processData)) {
                             $selectedSequenceFlow = $connectingObject;
                             break;

--- a/tests/Workflow/WorkflowTest.php
+++ b/tests/Workflow/WorkflowTest.php
@@ -15,6 +15,7 @@ namespace PHPMentors\Workflower\Workflow;
 use PHPMentors\Workflower\Workflow\Activity\ActivityInterface;
 use PHPMentors\Workflower\Workflow\Activity\WorkItem;
 use PHPMentors\Workflower\Workflow\Activity\WorkItemInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class WorkflowTest extends \PHPUnit_Framework_TestCase
 {
@@ -370,5 +371,20 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         $this->assertThat($activityLog->get(1)->getActivity(), $this->identicalTo($activityLog->get(3)->getActivity()));
         $this->assertThat($activityLog->get(1)->getWorkItem(), $this->logicalNot($this->identicalTo($activityLog->get(3)->getWorkItem())));
+    }
+
+    /**
+     * @test
+     */
+    public function injectExpressionLanguage()
+    {
+        $expressionLanguage = \Phake::mock(ExpressionLanguage::class);
+        \Phake::when($expressionLanguage)->evaluate($this->equalTo('rejected == true'))->thenReturn(true);
+
+        $workflow = $this->workflowRepository->findById('LoanRequestProcess');
+        $workflow->setExpressionLanguage($expressionLanguage);
+
+        $workflow->setProcessData(array('rejected' => false));
+        $workflow->start($workflow->getFlowObject('Start'));
     }
 }

--- a/tests/Workflow/WorkflowTest.php
+++ b/tests/Workflow/WorkflowTest.php
@@ -378,7 +378,7 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
      */
     public function injectExpressionLanguage()
     {
-        $expressionLanguage = \Phake::mock(ExpressionLanguage::class);
+        $expressionLanguage = \Phake::mock('Symfony\Component\ExpressionLanguage\ExpressionLanguage');
         \Phake::when($expressionLanguage)->evaluate($this->equalTo('rejected == true'))->thenReturn(true);
 
         $workflow = $this->workflowRepository->findById('LoanRequestProcess');


### PR DESCRIPTION
This PR enables to inject ExpressionLanguage to Workflow.
It will be particularly useful when you want to use some custom functions in the conditional expression.
Please confirm, and merge if you like. Thank you.
