### PR TITLE
Laneless process fails for no roles

### DIFF
--- a/src/Definition/Bpmn2Reader.php
+++ b/src/Definition/Bpmn2Reader.php
@@ -104,6 +104,24 @@ class Bpmn2Reader implements ServiceInterface
             }
         }
 
+        if (count($flowObjectRoles) <= 0) { // laneless flow, use participant name as role
+            $participants = [];
+            foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'participant') as $element) {
+                $participants[$element->getAttribute('processRef')] = $element->getAttribute('id');
+                $workflowBuilder->addRole(
+                    $element->getAttribute('id'),
+                    $element->hasAttribute('name') ? $element->getAttribute('name') : null
+                );
+            }
+
+            foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'process') as $element) {
+                foreach ($element->childNodes as $childElement) {
+                    if (!$childElement->hasAttributes()) continue;
+                    $flowObjectRoles[$childElement->getAttribute('id')] = $participants[$element->getAttribute('id')];
+                }
+            }
+        }
+
         $operations = array();
         foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'operation') as $element) {
             if (!$element->hasAttribute('id')) {

--- a/src/Definition/Bpmn2Reader.php
+++ b/src/Definition/Bpmn2Reader.php
@@ -105,7 +105,7 @@ class Bpmn2Reader implements ServiceInterface
         }
 
         if (count($flowObjectRoles) <= 0) { // laneless flow, use participant name as role
-            $participants = [];
+            $participants = array();
             foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'participant') as $element) {
                 $participants[$element->getAttribute('processRef')] = $element->getAttribute('id');
                 $workflowBuilder->addRole(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | BSD-2-Clause

If a process only has participants without lanes, the participant can act as the role. I'm not completely certain this is the right approach, but at the moment, not having a lane split causes the reader to crash.
