### PR TITLE
Support for BPMN models without swimlanes

### DIFF
--- a/src/Definition/Bpmn2Reader.php
+++ b/src/Definition/Bpmn2Reader.php
@@ -104,6 +104,10 @@ class Bpmn2Reader implements ServiceInterface
             }
         }
 
+        if (count($flowObjectRoles) == 0) {
+            $workflowBuilder->addRole(Workflow::DEFAULT_ROLE_ID);
+        }
+
         $operations = array();
         foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'operation') as $element) {
             if (!$element->hasAttribute('id')) {
@@ -120,7 +124,7 @@ class Bpmn2Reader implements ServiceInterface
 
             $workflowBuilder->addStartEvent(
                 $element->getAttribute('id'),
-                $flowObjectRoles[$element->getAttribute('id')],
+                $this->provideRoleIdForFlowObject($flowObjectRoles, $element->getAttribute('id')),
                 $element->hasAttribute('name') ? $element->getAttribute('name') : null,
                 $element->hasAttribute('default') ? $element->getAttribute('default') : null
             );
@@ -133,7 +137,7 @@ class Bpmn2Reader implements ServiceInterface
 
             $workflowBuilder->addTask(
                 $element->getAttribute('id'),
-                $flowObjectRoles[$element->getAttribute('id')],
+                $this->provideRoleIdForFlowObject($flowObjectRoles, $element->getAttribute('id')),
                 $element->hasAttribute('name') ? $element->getAttribute('name') : null,
                 $element->hasAttribute('default') ? $element->getAttribute('default') : null
             );
@@ -146,7 +150,7 @@ class Bpmn2Reader implements ServiceInterface
 
             $workflowBuilder->addServiceTask(
                 $element->getAttribute('id'),
-                $flowObjectRoles[$element->getAttribute('id')],
+                $this->provideRoleIdForFlowObject($flowObjectRoles, $element->getAttribute('id')),
                 $operations[$element->getAttribute('operationRef')],
                 $element->hasAttribute('name') ? $element->getAttribute('name') : null,
                 $element->hasAttribute('default') ? $element->getAttribute('default') : null
@@ -160,7 +164,7 @@ class Bpmn2Reader implements ServiceInterface
 
             $workflowBuilder->addExclusiveGateway(
                 $element->getAttribute('id'),
-                $flowObjectRoles[$element->getAttribute('id')],
+                $this->provideRoleIdForFlowObject($flowObjectRoles, $element->getAttribute('id')),
                 $element->hasAttribute('name') ? $element->getAttribute('name') : null,
                 $element->hasAttribute('default') ? $element->getAttribute('default') : null
             );
@@ -171,7 +175,7 @@ class Bpmn2Reader implements ServiceInterface
                 throw $this->createIdAttributeNotFoundException($element, $file);
             }
 
-            $workflowBuilder->addEndEvent($element->getAttribute('id'), $flowObjectRoles[$element->getAttribute('id')], $element->hasAttribute('name') ? $element->getAttribute('name') : null);
+            $workflowBuilder->addEndEvent($element->getAttribute('id'), $this->provideRoleIdForFlowObject($flowObjectRoles, $element->getAttribute('id')), $element->hasAttribute('name') ? $element->getAttribute('name') : null);
         }
 
         foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'sequenceFlow') as $element) {
@@ -206,5 +210,18 @@ class Bpmn2Reader implements ServiceInterface
     private function createIdAttributeNotFoundException(\DOMElement $element, $file)
     {
         return new IdAttributeNotFoundException(sprintf('The id attribute of the "%s" element is not found in "%s" on line %d', $element->tagName, $file, $element->getLineNo()));
+    }
+
+    /**
+     * @param array  $flowObjectRoles
+     * @param string $flowObjectId
+     *
+     * @return string
+     *
+     * @since Method available since Release 1.3.0
+     */
+    private function provideRoleIdForFlowObject(array $flowObjectRoles, $flowObjectId)
+    {
+        return count($flowObjectRoles) ? $flowObjectRoles[$flowObjectId] : Workflow::DEFAULT_ROLE_ID;
     }
 }

--- a/src/Workflow/Workflow.php
+++ b/src/Workflow/Workflow.php
@@ -42,6 +42,8 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class Workflow implements EntityInterface, IdentifiableInterface, \Serializable
 {
+    const DEFAULT_ROLE_ID = '__ROLE__';
+
     /**
      * @var string
      */
@@ -492,7 +494,7 @@ class Workflow implements EntityInterface, IdentifiableInterface, \Serializable
 
         if (!isset($selectedSequenceFlow)) {
             if (!($currentFlowObject instanceof ConditionalInterface) || $currentFlowObject->getDefaultSequenceFlowId() === null) {
-                throw new SequenceFlowNotSelectedException(sprintf('No sequence flow can be selected on "%s".',  $currentFlowObject->getId()));
+                throw new SequenceFlowNotSelectedException(sprintf('No sequence flow can be selected on "%s".', $currentFlowObject->getId()));
             }
 
             $selectedSequenceFlow = $this->connectingObjectCollection->get($currentFlowObject->getDefaultSequenceFlowId());

--- a/tests/Resources/config/workflower/NoLanesProcess.bpmn
+++ b/tests/Resources/config/workflower/NoLanesProcess.bpmn
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- origin at X=0.0 Y=0.0 -->
+<bpmn2:definitions xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:ext="http://org.eclipse.bpmn2/ext" id="Definitions_1" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.3.1.Final-v20160914-1606-B56" targetNamespace="http://org.eclipse.bpmn2/default/process">
+  <bpmn2:process id="NoLanesProcess" name="Default Process" isExecutable="false">
+    <bpmn2:startEvent id="Start" name="Start">
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" sourceRef="Start" targetRef="Task_1"/>
+    <bpmn2:endEvent id="End" name="End">
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:task id="Task_1" name="Task 1">
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="End"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1" name="Default Process Diagram">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="NoLanesProcess">
+      <bpmndi:BPMNShape id="BPMNShape_1" bpmnElement="Start">
+        <dc:Bounds height="36.0" width="36.0" x="100.0" y="100.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_1" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="22.0" width="43.0" x="97.0" y="136.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_2" bpmnElement="End">
+        <dc:Bounds height="36.0" width="36.0" x="500.0" y="100.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_3" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="22.0" width="35.0" x="500.0" y="136.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1" bpmnElement="Task_1" isExpanded="true">
+        <dc:Bounds height="50.0" width="110.0" x="260.0" y="93.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_4" labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds height="22.0" width="58.0" x="286.0" y="107.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="BPMNShape_1" targetElement="BPMNShape_Task_1">
+        <di:waypoint xsi:type="dc:Point" x="136.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="198.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="260.0" y="118.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_2"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_Task_1" targetElement="BPMNShape_2">
+        <di:waypoint xsi:type="dc:Point" x="370.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="435.0" y="118.0"/>
+        <di:waypoint xsi:type="dc:Point" x="500.0" y="118.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_5"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="BPMNLabelStyle_1">
+      <dc:Font name="arial" size="9.0"/>
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/tests/Workflow/WorkflowRepository.php
+++ b/tests/Workflow/WorkflowRepository.php
@@ -27,6 +27,7 @@ class WorkflowRepository implements WorkflowRepositoryInterface
         $this->add($this->createLoanRequestProcess());
         $this->add($this->createMultipleWorkItemsProcess());
         $this->add($this->createServiceTasksProcess());
+        $this->add($this->createNoLanesProcess());
     }
 
     /**
@@ -123,5 +124,17 @@ class WorkflowRepository implements WorkflowRepositoryInterface
         $bpmn2Reader = new Bpmn2Reader();
 
         return $bpmn2Reader->read(dirname(__DIR__).'/Resources/config/workflower/ServiceTasksProcess.bpmn');
+    }
+
+    /**
+     * @return Workflow
+     *
+     * @since Method available since Release 1.3.0
+     */
+    private function createNoLanesProcess()
+    {
+        $bpmn2Reader = new Bpmn2Reader();
+
+        return $bpmn2Reader->read(dirname(__DIR__).'/Resources/config/workflower/NoLanesProcess.bpmn');
     }
 }

--- a/tests/Workflow/WorkflowTest.php
+++ b/tests/Workflow/WorkflowTest.php
@@ -416,4 +416,25 @@ class WorkflowTest extends \PHPUnit_Framework_TestCase
 
         \Phake::verify($operationRunner, \Phake::times(2))->run($this->anything(), $this->anything());
     }
+
+    /**
+     * @test
+     *
+     * @since Method available since Release 1.3.0
+     */
+    public function provideDefaultRoleForWorkflowWithoutLanes()
+    {
+        $participant = \Phake::mock('PHPMentors\Workflower\Workflow\Participant\ParticipantInterface');
+        \Phake::when($participant)->hasRole($this->anything())->thenReturn(true);
+
+        $workflow = $this->workflowRepository->findById('NoLanesProcess');
+        $workflow->start($workflow->getFlowObject('Start'));
+        $workflow->allocateWorkItem($workflow->getCurrentFlowObject(), $participant);
+        $workflow->startWorkItem($workflow->getCurrentFlowObject(), $participant);
+        $workflow->completeWorkItem($workflow->getCurrentFlowObject(), $participant);
+
+        $this->assertThat($workflow->isEnded(), $this->isTrue());
+
+        \Phake::verify($participant, \Phake::times(3))->hasRole($this->equalTo(Workflow::DEFAULT_ROLE_ID));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `master`
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #23
| License       | BSD-2-Clause

This will provide support for BPMN models without swimlanes by providing the default role. All existing assertions in `allocateWorkItem()` / `startWorkItem()` / `completeWorkItem()` on `Workflow` that assert the participant acts as the given role will still be called with the default role ID `__ROLE__`.
