### PR TITLE
SendTask support

### DIFF
--- a/src/Definition/Bpmn2Reader.php
+++ b/src/Definition/Bpmn2Reader.php
@@ -104,6 +104,15 @@ class Bpmn2Reader implements ServiceInterface
             }
         }
 
+        $messages = array();
+        foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'message') as $element) {
+            if (!$element->hasAttribute('id')) {
+                throw $this->createIdAttributeNotFoundException($element, $file);
+            }
+
+            $messages[$element->getAttribute('id')] = $element->getAttribute('name');
+        }
+
         $operations = array();
         foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'operation') as $element) {
             if (!$element->hasAttribute('id')) {
@@ -148,6 +157,21 @@ class Bpmn2Reader implements ServiceInterface
                 $element->getAttribute('id'),
                 $flowObjectRoles[$element->getAttribute('id')],
                 $operations[$element->getAttribute('operationRef')],
+                $element->hasAttribute('name') ? $element->getAttribute('name') : null,
+                $element->hasAttribute('default') ? $element->getAttribute('default') : null
+            );
+        }
+
+        foreach ($document->getElementsByTagNameNs('http://www.omg.org/spec/BPMN/20100524/MODEL', 'sendTask') as $element) {
+            if (!$element->hasAttribute('id')) {
+                throw $this->createIdAttributeNotFoundException($element, $file);
+            }
+
+            $workflowBuilder->addSendTask(
+                $element->getAttribute('id'),
+                $flowObjectRoles[$element->getAttribute('id')],
+                $element->hasAttribute('messageRef') ? $messages[$element->getAttribute('messageRef')] : null,
+                $element->hasAttribute('operationRef') ? $operations[$element->getAttribute('operationRef')] : null,
                 $element->hasAttribute('name') ? $element->getAttribute('name') : null,
                 $element->hasAttribute('default') ? $element->getAttribute('default') : null
             );

--- a/src/Definition/Bpmn2Reader.php
+++ b/src/Definition/Bpmn2Reader.php
@@ -103,7 +103,7 @@ class Bpmn2Reader implements ServiceInterface
                 $flowObjectRoles[$childElement->nodeValue] = $element->getAttribute('id');
             }
         }
-      
+        
         if (count($flowObjectRoles) == 0) {
             $workflowBuilder->addRole(Workflow::DEFAULT_ROLE_ID);
         }

--- a/src/Workflow/Activity/SendTask.php
+++ b/src/Workflow/Activity/SendTask.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp> and contributors,
+ * All rights reserved.
+ *
+ * This file is part of Workflower.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\Workflower\Workflow\Activity;
+
+use PHPMentors\Workflower\Workflow\Resource\MessageInterface;
+use PHPMentors\Workflower\Workflow\Operation\OperationalInterface;
+use PHPMentors\Workflower\Workflow\Participant\Role;
+
+/**
+ *
+ */
+class SendTask extends Task implements MessageInterface, OperationalInterface
+{
+    /**
+     * @var int|string
+     */
+    private $message;
+
+    /**
+     * @var int|string
+     */
+    private $operation;
+
+    /**
+     * @param int|string $id
+     * @param Role       $role
+     * @param int|string $operation
+     * @param string     $name
+     */
+    public function __construct($id, Role $role, $message, $operation, $name = null)
+    {
+        parent::__construct($id, $role, $name);
+
+        $this->message = $message;
+        $this->operation = $operation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize(array(
+            get_parent_class($this) => parent::serialize(),
+            'message' => $this->message,
+            'operation' => $this->operation,
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        foreach (unserialize($serialized) as $name => $value) {
+            if ($name == get_parent_class($this)) {
+                parent::unserialize($value);
+                continue;
+            }
+
+            if (property_exists($this, $name)) {
+                $this->$name = $value;
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOperation()
+    {
+        return $this->operation;
+    }
+}

--- a/src/Workflow/Resource/MessageInterface.php
+++ b/src/Workflow/Resource/MessageInterface.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp> and contributors,
+ * All rights reserved.
+ *
+ * This file is part of Workflower.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\Workflower\Workflow\Resource;
+
+interface MessageInterface
+{
+    /**
+     * @return int|string
+     */
+    public function getMessage();
+}

--- a/src/Workflow/WorkflowBuilder.php
+++ b/src/Workflow/WorkflowBuilder.php
@@ -13,6 +13,7 @@
 namespace PHPMentors\Workflower\Workflow;
 
 use PHPMentors\Workflower\Workflow\Activity\ServiceTask;
+use PHPMentors\Workflower\Workflow\Activity\SendTask;
 use PHPMentors\Workflower\Workflow\Activity\Task;
 use PHPMentors\Workflower\Workflow\Connection\SequenceFlow;
 use PHPMentors\Workflower\Workflow\Event\EndEvent;
@@ -59,6 +60,11 @@ class WorkflowBuilder
      * @since Property available since Release 1.2.0
      */
     private $serviceTasks = array();
+
+    /**
+     * @var array
+     */
+    private $sendTasks = array();
 
     /**
      * @var string
@@ -203,6 +209,25 @@ class WorkflowBuilder
     }
 
     /**
+     * @param string     $id
+     * @param string     $participant
+     * @param string     $message
+     * @param string     $operation
+     * @param string     $name
+     * @param int|string $defaultSequenceFlow
+     *
+     * @since Method available since Release 1.2.0
+     */
+    public function addSendTask($id, $participant, $message, $operation, $name = null, $defaultSequenceFlow = null)
+    {
+        $this->sendTasks[$id] = array($participant, $message, $operation, $name);
+
+        if ($defaultSequenceFlow !== null) {
+            $this->defaultableFlowObjects[$defaultSequenceFlow] = $id;
+        }
+    }
+
+    /**
      * @return Workflow
      *
      * @throws \LogicException
@@ -242,6 +267,13 @@ class WorkflowBuilder
             $this->assertWorkflowHasRole($workflow, $roleId);
 
             $workflow->addFlowObject(new ServiceTask($id, $workflow->getRole($roleId), $operation, $name));
+        }
+
+        foreach ($this->sendTasks as $id => $task) {
+            list($roleId, $message, $operation, $name) = $task;
+            $this->assertWorkflowHasRole($workflow, $roleId);
+
+            $workflow->addFlowObject(new SendTask($id, $workflow->getRole($roleId), $message, $operation, $name));
         }
 
         foreach ($this->exclusiveGateways as $id => $gateway) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | BSD-2-Clause

Added support for SendTask. As per the BPMN2 specification, since a Send Task operation will send a message and then complete itself (and also has a field for operation reference), it uses the same mechanism as the OperationalInterface so can be passed to the OperationRunner for sending (check if implements MessageInterface).
