### PR TITLE
New minimum required Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.9",
         "phpmentors/domain-kata": "~1.4",
         "piece/stagehand-fsm": "~2.4",
-        "symfony/expression-language": "~2.7"
+        "symfony/expression-language": "~2.8|~3.0"
     },
     "require-dev": {
         "phake/phake": "~2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | BSD-2-Clause

This will change the the minimum required version of `symfony/expression-language` to `~2.8` or `~3.0`.
