### PR TITLE
New minimum required PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,8 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 matrix:
@@ -22,7 +19,7 @@ matrix:
 before_script:
   - rm -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   - composer self-update
-  - composer install
+  - if [[ $TRAVIS_PHP_VERSION = hhvm* ]]; then composer install --ignore-platform-reqs; else composer install; fi
 
 script:
   - ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9",
+        "php": ">=7.0.8",
         "ext-dom": "*",
         "phpmentors/domain-kata": "~1.4",
         "piece/stagehand-fsm": "~2.5",

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -2,7 +2,7 @@ version: '2'
 services:
     app:
         container_name: "phpmentors.workflower.app"
-        image: "phpmentors/php-app:php53"
+        image: "phpmentors/php-app:php70"
         volumes:
             - ".:/var/app"
         environment:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | BSD-2-Clause

This will change the minimum required PHP version to `7.0.8`.
