### PR TITLE
New dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": ">=5.3.9",
         "phpmentors/domain-kata": "~1.4",
-        "piece/stagehand-fsm": "~2.5",
-        "symfony/expression-language": "~2.8|~3.0"
+        "piece/stagehand-fsm": "~2.6",
+        "symfony/expression-language": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
         "phake/phake": "~2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | BSD-2-Clause

This will change some dependency versions including PHP as follows:

- piece/stagehand-fsm: >= 2.6.0
- symfony/expression-language: >= 2.8.0 or >= 3.4.0 or >= 4.0.0
