### PR TITLE
Fixing broken serialization for exclusive gateways

### DIFF
--- a/src/Workflow/Gateway/ExclusiveGateway.php
+++ b/src/Workflow/Gateway/ExclusiveGateway.php
@@ -58,7 +58,7 @@ class ExclusiveGateway implements GatewayInterface, \Serializable
             'id' => $this->id,
             'name' => $this->name,
             'role' => $this->role,
-            'defaultSequenceFlow' => $this->defaultSequenceFlowId,
+            'defaultSequenceFlowId' => $this->defaultSequenceFlowId,
         ));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #55
| License       | BSD-2-Clause

This fixes broken serialization for `ExclusiveGateway` objects.