### PR TITLE
Allow serialized workflow to be null

### DIFF
--- a/src/Persistence/WorkflowSerializableInterface.php
+++ b/src/Persistence/WorkflowSerializableInterface.php
@@ -18,12 +18,12 @@ use PHPMentors\Workflower\Workflow\Workflow;
 interface WorkflowSerializableInterface extends WorkflowAwareInterface
 {
     /**
-     * @param string $serializedWorkflow
+     * @param string|null $serializedWorkflow
      */
     public function setSerializedWorkflow($serializedWorkflow);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getSerializedWorkflow();
 


### PR DESCRIPTION
According to https://github.com/phpmentors-jp/workflower-bundle/blob/ecb52505923167b59e2445cfd939a29019ab2a72/src/Persistence/DoctrineLifecycleListener.php#L63 serialized workflow can be null. WorkflowSerializableInterface should be updated accordingly

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
